### PR TITLE
feat(order): add order listing support

### DIFF
--- a/controllers/whatsappController.js
+++ b/controllers/whatsappController.js
@@ -216,7 +216,12 @@ function getServiceCategories(req, res) {
 }
 
 function getAllOrders(req, res) {
-    res.status(200).json({ status: "OK", data: orderManager.getAllOrders() });
+    try {
+        const orders = orderManager.getAllOrders();
+        res.status(200).json({ status: "OK", data: orders });
+    } catch (error) {
+        res.status(500).json({ status: "Error", message: "Sifarişləri almaq mümkün olmadı.", error: error.message });
+    }
 }
 
 async function createOrder(req, res) {

--- a/services/orderManager.js
+++ b/services/orderManager.js
@@ -108,4 +108,47 @@ async function createOrder(leadId, customerPhone, itemId, quantity = 1) {
   };
 }
 
-module.exports = { createOrder };
+function getAllOrders() {
+    ensureOrdersFile();
+
+    const fileContents = fs.readFileSync(ordersFilePath, { encoding: 'utf8' });
+    if (!fileContents) return [];
+
+    const lines = fileContents
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(line => line.length > 0);
+
+    if (lines.length <= 1) return [];
+
+    return lines
+        .slice(1)
+        .map(line => {
+            const [
+                order_id,
+                lead_id,
+                customer_phone,
+                item_id,
+                quantity,
+                total_price,
+                status,
+                created_at,
+            ] = line.split(',');
+
+            if (!order_id) return null;
+
+            return {
+                order_id: order_id.trim(),
+                lead_id: (lead_id || '').trim() || null,
+                customer_phone: (customer_phone || '').trim(),
+                item_id: (item_id || '').trim(),
+                quantity: Number(quantity) || 0,
+                total_price: Number(total_price) || 0,
+                status: (status || '').trim(),
+                created_at: (created_at || '').trim(),
+            };
+        })
+        .filter(Boolean);
+}
+
+module.exports = { createOrder, getAllOrders };


### PR DESCRIPTION
## Summary
- add a CSV-backed `getAllOrders` helper that normalizes stored order rows into objects
- export the new helper alongside `createOrder` and surface it through the WhatsApp controller with error handling

## Testing
- npm test *(fails: No test files found "test/**/*.spec.js")*

------
https://chatgpt.com/codex/tasks/task_e_68c87b537da4832f9b91df1ffb84a2fa